### PR TITLE
Fix only 1 working placeholder window per group

### DIFF
--- a/i3-sticky
+++ b/i3-sticky
@@ -58,11 +58,11 @@ def swap(i3, _):
         i3.command('[workspace="__focused__" con_mark="^_sticky_%s_"] swap container with mark "_sticky_%s"' % (group, group))
 
 def on_new_window(i3, event):
-    instance = event.container.window_instance
+    instance = event.container.window_class
     if not instance:
         return
 
-    match = re.match(r'^i3-sticky-(.*)$', instance)
+    match = re.match(r'^I3-sticky-(.*)$', instance)
     if not match:
         return
 

--- a/i3-sticky-open
+++ b/i3-sticky-open
@@ -28,6 +28,6 @@ if __name__ == '__main__':
     if len(sys.argv) > 1:
         group = sys.argv[1]
 
-    win = tk.Tk(className="i3-sticky-%s" % group)
+    win = tk.Tk(className="I3-sticky-%s" % group)
     create_text_widget(win, 'Sticky Placeholder – Group %s' % group)
     win.mainloop()


### PR DESCRIPTION
Tk adds suffix to window_instance, to keep it unique, see https://bugs.python.org/issue30791
Use window_class instead